### PR TITLE
Example fail2ban config for ruroco

### DIFF
--- a/fail2ban/filter.d/ruroco.conf
+++ b/fail2ban/filter.d/ruroco.conf
@@ -1,0 +1,19 @@
+[Definition]
+# example log error
+#Aug 25 23:44:05 ns0 ruroco-server[667459]: [2024-08-25T23:44:06Z ERROR ] Invalid read count 256, expected 1024 from 10.0.0.2:50893
+# from `journalctl -fu ruroco`
+
+# the colour formatting in ruroco/src/common.rs:{info() error()} becomes invisible chars in journalctl chars around the 'ERROR'
+failregex = ^.*?ruroco-server\[\d+\]: \[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z[^E]*ERROR[^\]]*\] Invalid read count \d+, expected \d+ from <HOST>:\d+$
+# TODO Yet to be tested on IPv6
+# TODO see if a DoS with other UDP packerts show up in the logs for ruroco or ruroco-commander
+
+ignoreregex = ^.* INFO \] Successfully .*$
+
+datepattern = ^%%Y-%%m-%%dT%%H:%%M:%%SZ
+# DEV NOTES:
+#
+# Author: alexx
+# ver. 2024-Aug-26.001
+# testing: fail2ban-regex systemd-journal /etc/fail2ban/filter.d/ruroco.conf
+

--- a/fail2ban/ruroco.conf
+++ b/fail2ban/ruroco.conf
@@ -1,0 +1,7 @@
+[ruroco]
+enable  = true
+port    = 8080
+#backend = systed # enable if using journalctl
+#logfile = /var/log/syslog # if that is were logs are being sent
+filter  = ruroco
+maxretry = 5


### PR DESCRIPTION
If ruroco is protecting sshd it is only a matter of time before the scanners start hammering on ruroco's port

"Quis custodiet ipsos custodes?"

Needs to be tested with IPv6 and other UDP packets